### PR TITLE
.has() method and newValueCallback

### DIFF
--- a/ko.observableDictionary.js
+++ b/ko.observableDictionary.js
@@ -1,4 +1,4 @@
-﻿// Knockout Observable Dictionary
+// Knockout Observable Dictionary
 // (c) James Foster
 // License: MIT (http://www.opensource.org/licenses/mit-license.php)
 


### PR DESCRIPTION
I needed to have a Dictionary that is able to create a new value if a new key is accessed.
This change implements an optional newValueCallback argument.
If not specified, observableDictionary works as usual.
If specified with a callback, observableDictionary will call the callback with the key as it's first  argument. The return value of the callback will be used as the value for the new key.
You need this if the Knockout template is dynamically determined by the viewmodel itself.

In order to be able to check for existance of keys without using .get(), I also added a .has() method.
