### PR TITLE
Allow get to take a default value

### DIFF
--- a/ko.observableDictionary.js
+++ b/ko.observableDictionary.js
@@ -1,4 +1,4 @@
-﻿// Knockout Observable Dictionary
+// Knockout Observable Dictionary
 // (c) James Foster
 // License: MIT (http://www.opensource.org/licenses/mit-license.php)
 
@@ -141,7 +141,8 @@
             return -1;
         },
 
-        get: function (key, wrap) {
+        get: function (key, wrap, defaultValue) {
+
             if (wrap == false)
                 return getValue(key, this.items());
 
@@ -162,6 +163,7 @@
                             this.push(key, newValue);
                     }
                 }, this);
+                if(typeof(defaultValue)!='undefined') wrapper(defaultValue);
             }
 
             return wrapper;

--- a/ko.observableDictionary.js
+++ b/ko.observableDictionary.js
@@ -163,7 +163,12 @@
                             this.push(key, newValue);
                     }
                 }, this);
-                if(typeof(defaultValue)!='undefined') wrapper(defaultValue);
+                if (typeof (defaultValue) != 'undefined') {
+                    var value = getValue(key, this.items());
+                    if (!value) {
+                        wrapper(defaultValue);
+                    }
+                }
             }
 
             return wrapper;


### PR DESCRIPTION
Allow get to take a default value which is used when the wrapper is created. This ensures that you can initialize a dictionary item with a specific value if the key doesn't exist and you are creating the key dynamically.
